### PR TITLE
不要替换 `/system/fonts` 是否更好

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,6 @@ print_modname() {
 # Construct your own list here, it will override the example above
 # !DO NOT! remove this if you don't need to replace anything, leave it empty as it is now
 REPLACE="
-/system/fonts
 "
 #添加您要精简的APP/文件夹目录
 #例如：精简状态栏，找到状态栏目录为  /system/priv-app/SystemUI/SystemUI.apk     


### PR DESCRIPTION
在 HyperOS 1.0.4.0.UMREUXM 上安装本模块会导致启动时 HyperOS 屏幕出现后黑屏。若取出未覆盖的系统中的 `/system/fonts/MiSansVF.ttf` 放在本模块的 `system/fonts` 目录下则可正常使用，可能是因为某些系统应用用到了 MiSans 字体。尝试将该文件换成空文件也不行，能启动但 System UI 会直接崩溃。

因为这个字体好像不是开源的，直接放到仓库里似乎也不太好。但如果将 `/system/fonts` 从 `REPLACE` 中去掉，经测试本模块同样可成功替换字体并补全字重，不知道这样做是不是合理一点。